### PR TITLE
Import bs3 styles

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -39,81 +39,154 @@ var paths = {
 };
 
 
-function bootstrapCSS(cb) {
-
+function bootstrapCSS() {
     const bootstrapCSSSource = paths.styles["boostrap-ala"];
     const bootstrapCSSDest = paths.styles.dest;
-    //console.log('src: ' + bootstrapCSSSource);
-    //console.log('dest: ' + bootstrapCSSDest);
+    // Write unminified first (separate src so both outputs are always fresh)
     src(bootstrapCSSSource)
+        .pipe(gulpSass({precision: 9}).on('error', gulpSass.logError))
+        .pipe(rename('bootstrap.css'))
+        .pipe(dest(bootstrapCSSDest));
+    return src(bootstrapCSSSource)
         .pipe(gulpSass({precision: 9}).on('error', gulpSass.logError))
         .pipe(cleanCSS())
         .pipe(rename('bootstrap.min.css'))
         .pipe(dest(bootstrapCSSDest));
-    cb();
 }
 
-function autocompleteCSS(cb) {
-    src(paths.styles.jqueryui)
+function autocompleteCSS() {
+    return src(paths.styles.jqueryui)
         .pipe(rename('autocomplete.css'))
         .pipe(dest(paths.styles.dest))
         .pipe(cleanCSS())
         .pipe(rename('autocomplete.min.css'))
         .pipe(dest(paths.styles.dest));
-    cb();
 }
 
-function fontawesome(cb) {
-    src(paths.styles["font-awesome"])
+function fontawesome() {
+    return src(paths.styles["font-awesome"])
         .pipe(gulpSass({precision: 9}).on('error', gulpSass.logError))
         .pipe(rename('font-awesome.css'))
         .pipe(dest(paths.styles.dest))
         .pipe(cleanCSS())
         .pipe(rename('font-awesome.min.css'))
         .pipe(dest(paths.styles.dest));
-    cb();
 }
 
-function otherCSSFiles(cb) {
-    src(paths.styles.dependencycss)
+function otherCSSFiles() {
+    return src(paths.styles.dependencycss)
         .pipe(dest(paths.styles.dest))
         .pipe(cleanCSS())
         .pipe(rename({extname: '.min.css'}))
         .pipe(dest(paths.styles.dest));
-    cb();
 }
 
 var css = parallel(bootstrapCSS, fontawesome, autocompleteCSS, otherCSSFiles);
 
+function applyMustache(content, vars) {
+    Object.keys(vars).forEach(function(key) {
+        content = content.split('{{' + key + '}}').join(vars[key] != null ? String(vars[key]) : '');
+    });
+    content = content.split('==homeDomain==').join(buildvars.homeDomain);
+    content = content.split('==signUpURL==').join(buildvars.signUpURL);
+    content = content.split('==profileURL==').join(buildvars.profileURL);
+    content = content.split('==fathomID==').join(buildvars.fathomID);
+    return content;
+}
+
+// Shared test values
+var TEST_HEADER_FOOTER_SERVER = 'https://www-test.ala.org.au/commonui-bs5-2019/';
+var TEST_SEARCH_SERVER        = 'https://bie.ala.org.au';
+var TEST_SEARCH_PATH          = '/search';
+var TEST_LOGIN_URL            = 'https://auth-test.ala.org.au/cas/login?service=https%3A%2F%2Ftest.ala.org.au%2F';
+var TEST_LOGOUT_URL           = 'https://auth-test.ala.org.au/cas/logout';
+var TEST_PROFILE_URL          = buildvars.profileURL;
+
+// The four rendering combinations
+var VARIANTS = [
+    { name: 'container-signedOut',   containerClass: 'container',       loginStatus: 'signedOut', loggedIn: false, loggedOut: true  },
+    { name: 'container-signedIn',    containerClass: 'container',       loginStatus: 'signedIn',  loggedIn: true,  loggedOut: false },
+    { name: 'fluid-signedOut',       containerClass: 'container-fluid', loginStatus: 'signedOut', loggedIn: false, loggedOut: true  },
+    { name: 'fluid-signedIn',        containerClass: 'container-fluid', loginStatus: 'signedIn',  loggedIn: true,  loggedOut: false },
+];
+
+function buildMustacheVars(variant) {
+    return {
+        headerFooterServer : TEST_HEADER_FOOTER_SERVER,
+        centralServer      : buildvars.homeDomain,
+        searchServer       : TEST_SEARCH_SERVER,
+        searchPath         : TEST_SEARCH_PATH,
+        containerClass     : variant.containerClass,
+        loginURL           : TEST_LOGIN_URL,
+        logoutURL          : TEST_LOGOUT_URL,
+        myProfileURL       : TEST_PROFILE_URL,
+        editAccountLink    : TEST_PROFILE_URL,
+        loginStatus        : variant.loginStatus,
+        loggedIn           : variant.loggedIn,
+        loggedOut          : variant.loggedOut,
+        fathomID           : buildvars.fathomID
+    };
+}
+
+/**
+ * Render standalone banner-*.html and footer-*.html files for each variant.
+ */
+function testHTMLVariants(cb) {
+    var bannerTemplate = fs.readFileSync('source/html/banner.mustache', 'utf8');
+    var footerTemplate = fs.readFileSync('source/html/footer.mustache', 'utf8');
+
+    VARIANTS.forEach(function(variant) {
+        var vars = buildMustacheVars(variant);
+        fs.writeFileSync(
+            'build/banner-' + variant.name + '.html',
+            applyMustache(bannerTemplate, vars)
+        );
+        fs.writeFileSync(
+            'build/footer-' + variant.name + '.html',
+            applyMustache(footerTemplate, vars)
+        );
+    });
+    cb();
+}
+
 function testHTMLPage() {
-    var header = fs.readFileSync('source/html/banner.mustache');
-    var footer = fs.readFileSync('source/html/footer.mustache');
+    var bannerTemplate = fs.readFileSync('source/html/banner.mustache', 'utf8');
+    var footerTemplate = fs.readFileSync('source/html/footer.mustache', 'utf8');
+
+    // Render all 4 banner+footer combinations
+    var renderedVariants = VARIANTS.map(function(variant) {
+        var vars = buildMustacheVars(variant);
+        return {
+            name:   variant.name,
+            banner: applyMustache(bannerTemplate, vars),
+            footer: applyMustache(footerTemplate, vars)
+        };
+    });
+
     return src('source/html/testTemplate.html')
-        .pipe(replace('HEADER_HERE', header))
-        .pipe(replace('FOOTER_HERE', footer))
-        .pipe(replace(/::containerClass::/g, 'container-fluid'))
-        .pipe(replace(/::headerFooterServer::/g, 'https://www-test.ala.org.au/commonui-bs5-2019/'))
-        .pipe(replace(/::loginStatus::/g, 'signedOut'))
-        .pipe(replace(/::loginURL::/g, 'https://auth.ala.org.au/cas/login'))
-        .pipe(replace(/::logoutURL::/g, 'https://auth.ala.org.au/cas/logout'))
-        .pipe(replace(/::searchServer::/g, 'https://bie.ala.org.au'))
-        .pipe(replace(/::searchPath::/g, '/search'))
+        .pipe(replace('VARIANT_CONTAINER_SIGNEDOUT_HEADER', renderedVariants[0].banner))
+        .pipe(replace('VARIANT_CONTAINER_SIGNEDIN_HEADER',  renderedVariants[1].banner))
+        .pipe(replace('VARIANT_FLUID_SIGNEDOUT_HEADER',     renderedVariants[2].banner))
+        .pipe(replace('VARIANT_FLUID_SIGNEDIN_HEADER',      renderedVariants[3].banner))
+        .pipe(replace('VARIANT_CONTAINER_SIGNEDOUT_FOOTER', renderedVariants[0].footer))
+        .pipe(replace('VARIANT_CONTAINER_SIGNEDIN_FOOTER',  renderedVariants[1].footer))
+        .pipe(replace('VARIANT_FLUID_SIGNEDOUT_FOOTER',     renderedVariants[2].footer))
+        .pipe(replace('VARIANT_FLUID_SIGNEDIN_FOOTER',      renderedVariants[3].footer))
         .pipe(replace(/==homeDomain==/g, buildvars.homeDomain))
-        .pipe(replace(/==signUpURL==/g, buildvars.signUpURL))
+        .pipe(replace(/==signUpURL==/g,  buildvars.signUpURL))
         .pipe(replace(/==profileURL==/g, buildvars.profileURL))
-        .pipe(replace(/==fathomID==/g, buildvars.fathomID))
+        .pipe(replace(/==fathomID==/g,   buildvars.fathomID))
         .pipe(rename('testPage.html'))
         .pipe(dest(paths.mustache.dest));
 };
 
-function mustache(cb) {
-    src(paths.mustache.src)
+function mustache() {
+    return src(paths.mustache.src)
         .pipe(replace(/==homeDomain==/g, buildvars.homeDomain))
         .pipe(replace(/==signUpURL==/g, buildvars.signUpURL))
         .pipe(replace(/==profileURL==/g, buildvars.profileURL))
         .pipe(replace(/==fathomID==/g, buildvars.fathomID))
         .pipe(dest(paths.mustache.dest));
-    cb();
 };
 
 function font() {
@@ -121,12 +194,11 @@ function font() {
         .pipe(dest(paths.font.dest));
 }
 
-function jQuery(cb) {
-    src(paths.js.jquery)
+function jQuery() {
+    return src(paths.js.jquery)
         .pipe(uglify({output: {comments: '/^!/'}}))
         .pipe(rename('jquery.min.js'))
         .pipe(dest(paths.js.dest));
-    cb();
 }
 
 function bootstrapJS() {
@@ -154,13 +226,13 @@ function otherJsFiles() {
 
 var js = parallel(jQuery, bootstrapJS, autocompleteJS, otherJsFiles);
 
-var build = parallel(css, testHTMLPage, mustache, font, js);
+var build = parallel(css, series(testHTMLVariants, testHTMLPage), mustache, font, js);
 
 exports.otherCSSFiles = otherCSSFiles;
-  
+
 exports.default = build;
 exports.css = css;
 exports.font = font;
 exports.js = js;
-exports.mustache = series([testHTMLPage, mustache]);
+exports.mustache = series([testHTMLVariants, testHTMLPage, mustache]);
 exports.build = build;

--- a/source/css/ala-styles.css
+++ b/source/css/ala-styles.css
@@ -23,10 +23,6 @@ body.background-lightgrey {background-color:#f2f2f2;}
 /* Headings
 ================================= */
 
-h1 a, h2 a, h3 a, h4 a, h5 a, h6 a {
-    text-decoration: none;
-}
-
 /* Breadcrumb
 ================================= */
 section#breadcrumb {padding: 12px 0 15px 19px;border-bottom: 1px solid #E7E7E7;background-color: #E7E7E7;}

--- a/source/css/ala-styles.css
+++ b/source/css/ala-styles.css
@@ -14,10 +14,57 @@ body.background-lightgrey {background-color:#f2f2f2;}
 
 /* Buttons
 ================================= */
-.btn-primary {
-    background-color: #c44d34;
-    color: white;
-    border-color: #c44d34;
+
+/* btn-primary: match BS3 (#c44d34 bg, white text; darken on hover/focus/active) */
+.btn-primary, .gform_button {
+    --bs-btn-color: #fff;
+    --bs-btn-bg: #c44d34;
+    --bs-btn-border-color: #c44d34;
+    --bs-btn-hover-color: #fff;
+    --bs-btn-hover-bg: #9c3d29;
+    --bs-btn-hover-border-color: #943a27;
+    --bs-btn-focus-shadow-rgb: 156, 61, 41;
+    --bs-btn-active-color: #fff;
+    --bs-btn-active-bg: #9c3d29;
+    --bs-btn-active-border-color: #943a27;
+    --bs-btn-disabled-color: #fff;
+    --bs-btn-disabled-bg: #c44d34;
+    --bs-btn-disabled-border-color: #c44d34;
+}
+
+/* btn-outline-dark: match BS3 btn-default (white bg, black text, #999 border; grey on hover/active) */
+.btn-outline-dark {
+    --bs-btn-color: #000;
+    --bs-btn-bg: #fff;
+    --bs-btn-border-color: #999;
+    --bs-btn-hover-color: #000;
+    --bs-btn-hover-bg: #e6e6e6;
+    --bs-btn-hover-border-color: #7a7a7a;
+    --bs-btn-focus-shadow-rgb: 130, 138, 145;
+    --bs-btn-active-color: #000;
+    --bs-btn-active-bg: #e6e6e6;
+    --bs-btn-active-border-color: #7a7a7a;
+    --bs-btn-disabled-color: #000;
+    --bs-btn-disabled-bg: #fff;
+    --bs-btn-disabled-border-color: #999;
+}
+
+/* btn-danger: match BS3 darken states (#bd2130 hover/active, #b51f2e border) */
+.btn-danger {
+    --bs-btn-hover-color: #fff;
+    --bs-btn-hover-bg: #bd2130;
+    --bs-btn-hover-border-color: #b51f2e;
+    --bs-btn-focus-shadow-rgb: 225, 83, 97;
+    --bs-btn-active-color: #fff;
+    --bs-btn-active-bg: #bd2130;
+    --bs-btn-active-border-color: #b51f2e;
+}
+
+/* BS3 applied focus ring on :focus (mouse + keyboard); BS5 restricts to :focus-visible (keyboard only).
+   Re-add :focus so the native browser focus ring appears, matching BS3 behaviour. */
+.btn:focus, .gform_button:focus, .btn.focus, .focus.gform_button, .btn:active:focus, .btn:active.focus, .btn.active:focus, .btn.active.focus {
+    outline: 5px auto -webkit-focus-ring-color;
+    outline-offset: -2px;
 }
 
 /* Headings
@@ -50,12 +97,6 @@ section#breadcrumb li + li::before {
     background-color: #f5f5f5;
     border: 1px solid #e3e3e3;
     border-radius: 4px;
-}
-.card-ala-light .btn-outline-dark {
-    background-color: white;
-}
-.card-ala-light .btn-outline-dark:hover {
-    background-color: #212529;
 }
 
 /* table of contents floating div */

--- a/source/css/ala-styles.css
+++ b/source/css/ala-styles.css
@@ -98,6 +98,21 @@ body.background-lightgrey {background-color:#f2f2f2;}
 
 /* Headings
 ================================= */
+h1, .h1, h2, .h2, h3, .h3 {
+    margin-top: 20px;
+    margin-bottom: 10px;
+}
+
+h1 small, h1 .small, .h1 small, .h1 .small,
+h2 small, h2 .small, .h2 small, .h2 .small,
+h3 small, h3 .small, .h3 small, .h3 .small {
+    font-size: 65%;
+}
+
+h4, .h4, h5, .h5, h6, .h6 {
+    margin-top: 10px;
+    margin-bottom: 10px;
+}
 
 /* Breadcrumb
 ================================= */

--- a/source/css/ala-styles.css
+++ b/source/css/ala-styles.css
@@ -101,6 +101,34 @@ body.background-lightgrey {background-color:#f2f2f2;}
     outline-offset: -2px;
 }
 
+/* Nav / Tabs
+================================= */
+
+/* nav-link: BS3 padding was 10px 15px; BS5 is 0.5rem 1rem (8px 16px) */
+.nav-link {
+    padding: 10px 15px;
+}
+
+/* nav-link hover: BS3 showed a grey background; BS5 only changes colour */
+.nav-link:hover, .nav-link:focus {
+    background-color: #f2f2f2;
+}
+
+/* nav-link focus: BS5 uses an orange box-shadow; restore native outline like BS3 */
+.nav-link:focus-visible {
+    outline: 5px auto -webkit-focus-ring-color;
+    outline-offset: -2px;
+    box-shadow: none;
+}
+
+/* nav-tabs: fix tab border-radius to match BS3's 4px (BS5 uses --bs-border-radius = 0.375rem / 6px)
+   and fix active tab border/colour to match BS3 exactly */
+.nav-tabs {
+    --bs-nav-tabs-border-radius: 4px;
+    --bs-nav-tabs-link-active-color: #6c757d;
+    --bs-nav-tabs-link-active-border-color: #999 #999 #fff;
+}
+
 /* Headings
 ================================= */
 h1, .h1, h2, .h2, h3, .h3 {
@@ -119,6 +147,41 @@ h4, .h4, h5, .h5, h6, .h6 {
     margin-bottom: 10px;
 }
 
+/* Typography
+================================= */
+
+/* label: BS3 font-weight: bold (700) and margin-bottom: 5px; BS5 has neither */
+label {
+    font-weight: 700;
+    margin-bottom: 5px;
+}
+
+/* small: BS3 uses 80%; BS5 uses 0.875em */
+small, .small {
+    font-size: 80%;
+}
+
+/* hr: BS5 adds opacity: 0.25 making it very faint; BS3 hr was fully opaque */
+hr {
+    opacity: 1;
+}
+
+/* form-control: BS3 uses 1px solid #999 border and 4px radius; BS5 defaults differ */
+.form-control {
+    border: 1px solid #999;
+    border-radius: 4px;
+}
+
+/* form-control readonly/disabled: BS3 uses #f2f2f2 bg and opacity: 1 for both;
+   disabled also gets cursor: not-allowed. BS5 has no readonly background rule. */
+.form-control[disabled], .form-control[readonly], fieldset[disabled] .form-control {
+    background-color: #f2f2f2;
+    opacity: 1;
+}
+
+.form-control[disabled], fieldset[disabled] .form-control {
+    cursor: not-allowed;
+}
 /* Breadcrumb
 ================================= */
 section#breadcrumb {padding: 12px 0 15px 19px;border-bottom: 1px solid #E7E7E7;background-color: #E7E7E7;}

--- a/source/css/ala-styles.css
+++ b/source/css/ala-styles.css
@@ -30,6 +30,26 @@ body.background-lightgrey {background-color:#f2f2f2;}
     --bs-gutter-x: 1.875rem;
 }
 
+/* Match BS3 container widths at the three shared breakpoints.
+   BS5 uses max-width; values differ: 720/960/1140 vs BS3's 750/970/1170. */
+@media (min-width: 768px) {
+    .container {
+        max-width: 750px;
+    }
+}
+
+@media (min-width: 992px) {
+    .container {
+        max-width: 970px;
+    }
+}
+
+@media (min-width: 1200px) {
+    .container {
+        max-width: 1170px;
+    }
+}
+
 /* BS5 applies gutter padding to all .row > * children; BS3 only applies it to .col-* children.
    Reset padding on non-col direct children, then re-apply only to col-* children. */
 .row > * {

--- a/source/css/ala-styles.css
+++ b/source/css/ala-styles.css
@@ -89,6 +89,11 @@ body.background-lightgrey {background-color:#f2f2f2;}
     --bs-btn-active-border-color: #b51f2e;
 }
 
+/* btn-sm: match BS3 border-radius of 3px; BS5 uses --bs-border-radius-sm = 0.25rem (4px) */
+.btn-sm, .btn-group-sm > .btn, .btn-group-sm > .gform_button {
+    --bs-btn-border-radius: 3px;
+}
+
 /* BS3 applied focus ring on :focus (mouse + keyboard); BS5 restricts to :focus-visible (keyboard only).
    Re-add :focus so the native browser focus ring appears, matching BS3 behaviour. */
 .btn:focus, .gform_button:focus, .btn.focus, .focus.gform_button, .btn:active:focus, .btn:active.focus, .btn.active:focus, .btn.active.focus {

--- a/source/css/ala-styles.css
+++ b/source/css/ala-styles.css
@@ -12,6 +12,35 @@ body.background-lightgrey {background-color:#f2f2f2;}
 .no-gutter>[class*='col-']{padding-right:0;padding-left:0;}
 .col-centered{float:none;margin:0 auto;}
 
+/* Match BS3 .row margins: BS3 uses -15px / 15px gutters; BS5 default is -12px / 12px (1.5rem gutter).
+   Override --bs-gutter-x to 1.875rem (30px) so calc(-0.5 * 30px) = -15px each side. */
+.row {
+    --bs-gutter-x: 1.875rem;
+}
+
+/* Match BS3 container/container-fluid padding: BS3 uses 15px each side; BS5 default is 12px (0.75rem).
+   Override --bs-gutter-x to 1.875rem (30px) so calc(0.5 * 30px) = 15px each side. */
+.container,
+.container-fluid,
+.container-xxl,
+.container-xl,
+.container-lg,
+.container-md,
+.container-sm {
+    --bs-gutter-x: 1.875rem;
+}
+
+/* BS5 applies gutter padding to all .row > * children; BS3 only applies it to .col-* children.
+   Reset padding on non-col direct children, then re-apply only to col-* children. */
+.row > * {
+    padding-right: 0;
+    padding-left: 0;
+}
+.row > [class*="col-"], .row > .col {
+    padding-right: calc(var(--bs-gutter-x) * .5);
+    padding-left: calc(var(--bs-gutter-x) * .5);
+}
+
 /* Buttons
 ================================= */
 

--- a/source/css/ala-styles.css
+++ b/source/css/ala-styles.css
@@ -81,6 +81,46 @@ body.background-lightgrey {background-color:#f2f2f2;}
     --bs-btn-disabled-border-color: #c44d34;
 }
 
+/* footer btn-primary: matches the navbar orange (#f26649), not the default dark red */
+footer .btn-primary, footer .gform_button {
+    --bs-btn-color: #212121;
+    --bs-btn-bg: #f26649;
+    --bs-btn-border-color: #f26649;
+    --bs-btn-hover-color: #212121;
+    --bs-btn-hover-bg: #ef4825;
+    --bs-btn-hover-border-color: #ef3e19;
+    --bs-btn-active-color: #fff;
+    --bs-btn-active-bg: #ef3e19;
+    --bs-btn-active-border-color: #eb3611;
+    --bs-btn-disabled-color: #212121;
+    --bs-btn-disabled-bg: #f26649;
+    --bs-btn-disabled-border-color: #f26649;
+}
+
+/* footer btn-outline-light: explicitly scoped to match the navbar header values */
+footer .btn-outline-light {
+    --bs-btn-color: #fff;
+    --bs-btn-bg: transparent;
+    --bs-btn-border-color: #fff;
+    --bs-btn-hover-color: #212121;
+    --bs-btn-hover-bg: #fff;
+    --bs-btn-hover-border-color: #fff;
+    --bs-btn-active-color: #212121;
+    --bs-btn-active-bg: #fff;
+    --bs-btn-active-border-color: #fff;
+    --bs-btn-disabled-color: #fff;
+    --bs-btn-disabled-bg: transparent;
+    --bs-btn-disabled-border-color: #fff;
+}
+
+/* footer button padding: match navbar context (5px 30px base, 4px 18px for btn-sm) */
+footer .btn, footer .gform_button {
+    padding: 5px 30px;
+}
+footer .btn-sm, footer .btn-group-sm > .btn, footer .btn-group-sm > .gform_button {
+    padding: 4px 18px;
+}
+
 /* btn-outline-dark: match BS3 btn-default (white bg, black text, #999 border; grey on hover/active) */
 .btn-outline-dark {
     --bs-btn-color: #000;
@@ -112,6 +152,55 @@ body.background-lightgrey {background-color:#f2f2f2;}
 /* btn-sm: match BS3 border-radius of 3px; BS5 uses --bs-border-radius-sm = 0.25rem (4px) */
 .btn-sm, .btn-group-sm > .btn, .btn-group-sm > .gform_button {
     --bs-btn-border-radius: 3px;
+}
+
+/* btn-outline-light: used in navbar and footer on dark backgrounds.
+   BS3 had this class; BS5 only has btn-outline-light which uses grey (#ced4da) instead of white. */
+.btn-outline-light {
+    --bs-btn-color: #fff;
+    --bs-btn-bg: transparent;
+    --bs-btn-border-color: #fff;
+    --bs-btn-hover-color: #212121;
+    --bs-btn-hover-bg: #fff;
+    --bs-btn-hover-border-color: #fff;
+    --bs-btn-focus-shadow-rgb: 255, 255, 255;
+    --bs-btn-active-color: #212121;
+    --bs-btn-active-bg: #fff;
+    --bs-btn-active-border-color: #fff;
+    --bs-btn-disabled-color: #fff;
+    --bs-btn-disabled-bg: transparent;
+    --bs-btn-disabled-border-color: #fff;
+}
+
+/* Footer button focus box-shadows: match BS3 #wrapper-navbar>nav / footer context rules.
+   The navbar equivalents live in _header.scss; footer is styled here. */
+footer .btn:focus, footer .gform_button:focus, footer .btn.focus, footer .focus.gform_button {
+    outline: 0;
+    box-shadow: 0 0 0 .2rem rgba(242, 102, 73, .25);
+}
+footer .btn-primary:focus, footer .btn-primary.focus {
+    box-shadow: 0 0 0 .2rem rgba(242, 102, 73, .5);
+}
+footer .btn-outline-light:focus, footer .btn-outline-light.focus {
+    box-shadow: 0 0 0 .2rem rgba(255, 255, 255, .5);
+}
+footer .btn-outline-dark:focus, footer .btn-outline-dark.focus {
+    box-shadow: 0 0 0 .2rem rgba(130, 138, 145, .5);
+}
+footer .btn-secondary:focus, footer .btn-secondary.focus {
+    box-shadow: 0 0 0 .2rem rgba(99, 112, 115, .5);
+}
+footer .btn-success:focus, footer .btn-success.focus {
+    box-shadow: 0 0 0 .2rem rgba(40, 167, 69, .5);
+}
+footer .btn-info:focus, footer .btn-info.focus {
+    box-shadow: 0 0 0 .2rem rgba(23, 162, 184, .5);
+}
+footer .btn-warning:focus, footer .btn-warning.focus {
+    box-shadow: 0 0 0 .2rem rgba(255, 193, 7, .5);
+}
+footer .btn-danger:focus, footer .btn-danger.focus {
+    box-shadow: 0 0 0 .2rem rgba(220, 53, 69, .5);
 }
 
 /* BS3 applied focus ring on :focus (mouse + keyboard); BS5 restricts to :focus-visible (keyboard only).

--- a/source/html/banner.mustache
+++ b/source/html/banner.mustache
@@ -115,7 +115,6 @@
                                 <li><a href="==homeDomain==/publications/" class="dropdown-item">Brochures and reports</a></li>
                                  <li><a href="==homeDomain==/ala-logo-and-identity/" class="dropdown-item">ALA logo and identity</a></li>
                                 <li><a href="==homeDomain==/ala-cited-publications/" class="dropdown-item">ALA-cited publications</a></li>
-                                <li><a href="==homeDomain==/education-resources/" class="dropdown-item">Education resources</a></li>
                                 <li><a href="==homeDomain==/abdmp/" class="dropdown-item">Data Mobilisation Program</a></li>
                                 <li><a href="https://labs.ala.org.au/" class="dropdown-item">ALA Labs</a></li>
                             </ul>

--- a/source/html/banner.mustache
+++ b/source/html/banner.mustache
@@ -1,7 +1,7 @@
 <div id="wrapper-navbar" itemscope="" itemtype="http://schema.org/WebSite">
     <a class="skip-link visually-hidden visually-hidden-focusable" href="#INSERT_CONTENT_ID_HERE">Skip to content</a>
 
-    <nav class="navbar navbar-dark navbar-expand-md">
+    <nav class="navbar navbar-dark navbar-expand-lg">
         <div class="{{containerClass}} header-logo-menu">
             <div class="navbar-header">
                 <div>
@@ -12,7 +12,7 @@
                              sizes="(max-width: 1005px) 100vw, 1005px"> </a>
                 </div>
                 <div class="display-flex {{loginStatus}}">
-                    <button class="display-flex search-trigger d-md-none d-lg-none collapsed collapse-trigger-button" title="Open search dialog"
+                    <button class="display-flex search-trigger d-lg-none collapsed collapse-trigger-button" title="Open search dialog"
                             data-bs-toggle="collapse" data-bs-target="#autocompleteSearchALA"
                             onclick="focusOnClickSearchButton()">
                         <svg xmlns="http://www.w3.org/2000/svg" width="25" height="18" viewBox="0 0 22 22">
@@ -30,12 +30,14 @@
                         </svg>
                         <span class="collapse visible-on-show" aria-hidden="true">&times;</span>
                     </button>
-                    <a href="{{loginURL}}" role="button" class="account-mobile d-md-none d-lg-none loginBtn mobile-login-btn"
+                    <a href="{{loginURL}}" role="button" class="account-mobile d-lg-none loginBtn mobile-login-btn"
                        title="Login button">
-                        <i class="fas fa-sign-in"></i>
+                        <svg xmlns="http://www.w3.org/2000/svg" width="25" height="25" viewBox="0 0 24 24" aria-hidden="true">
+                            <path d="M10 17v-3H3v-4h7V7l5 5-5 5Zm7 3h-7v-2h7V6h-7V4h7a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2Z"></path>
+                        </svg>
                     </a>
                     <a href="==profileURL==" role="button"
-                       class="account-mobile d-md-none d-lg-none myProfileBtn" title="Profile">
+                       class="account-mobile d-lg-none myProfileBtn" title="Profile">
                         <svg xmlns="http://www.w3.org/2000/svg" width="25" height="18" viewBox="0 0 37 41">
                             <defs>
                                 <style>
@@ -51,22 +53,24 @@
                         </svg>
                     </a>
                     <a href="{{logoutURL}}" role="button"
-                       class="account-mobile d-md-none d-lg-none logoutBtn mobile-logout-btn" title="Logout">
-                        <i class="fas fa-sign-out"></i>
+                       class="account-mobile d-lg-none logoutBtn mobile-logout-btn" title="Logout">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="25" height="25" viewBox="0 0 24 24" aria-hidden="true">
+                            <path d="M14 17v-3H7v-4h7V7l5 5-5 5Zm-3 3H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h7v2H4v12h7v2Z"></path>
+                        </svg>
                     </a>
-                    <button class="navbar-toggler collapsed collapse-trigger-button" type="button"
-                            data-bs-toggle="collapse" data-bs-target="#navbarOuterWrapper" aria-controls="navbarOuterWrapper"
+                    <div class="mobile-nav-toggle d-lg-none collapsed collapse-trigger-button"
+                            data-bs-toggle="collapse" data-bs-target="#navbarNavDropdown" aria-controls="navbarNavDropdown"
                             aria-expanded="false" aria-label="Toggle navigation">
                         <div class="horizontal-line"></div>
                         <div class="horizontal-line"></div>
                         <div class="horizontal-line"></div>
                         <span class="collapse visible-on-show" aria-hidden="true">&times;</span>
-                    </button>
+                    </div>
                 </div>
             </div>
 
-            <div id="navbarOuterWrapper" class="outer-nav-wrapper collapse navbar-collapse">
-                <div class="top-bar d-none d-sm-block hidden-sm">
+            <div id="navbarOuterWrapper" class="outer-nav-wrapper">
+                <div class="top-bar d-none d-lg-flex">
                     <a href="==homeDomain==/contact-us/" class="btn btn-link btn-sm">Contact us</a>
                     <div class="account {{loginStatus}}">
                         <a href="==signUpURL=="
@@ -154,7 +158,7 @@
                         </ul>
                       </div>
 
-                    <button class="search-trigger d-none d-sm-block hidden-sm collapsed collapse-trigger-button"
+                    <button class="search-trigger d-none d-lg-block collapsed collapse-trigger-button"
                             data-bs-toggle="collapse"
                             data-bs-target="#autocompleteSearchALA" onclick="focusOnClickSearchButton()">
                         <svg xmlns="http://www.w3.org/2000/svg" width="25" height="25" viewBox="0 0 22 22"

--- a/source/html/footer.mustache
+++ b/source/html/footer.mustache
@@ -1,7 +1,7 @@
 <footer class="site-footer bootstrap" id="colophon">
     <div class="footer-top">
         <div class="container">
-            <div class="row align-items-center">
+            <div class="row align-items-center align-items-baseline">
                 <div class="col-sm-12 col-md-4 align-center logo-column">
                     <img width="1005" src="https://www.ala.org.au/app/uploads/2019/01/logo.png" class="custom-logo"
                          alt="Atlas of Living Australia" itemprop="logo"
@@ -32,7 +32,7 @@
                                  alt="">
                         </div>
                         <div class="flex-grow-1 ms-3">
-                            <h4 class="h4"><a class="underline"
+                            <h4 class="h4"><a class="text-decoration-underline"
                                               href="==homeDomain==/home/record-a-sighting/">Record
                                 a Sighting</a></h4>
                             <p>Upload your observations, identify species, and contribute to the ALA.</p>
@@ -47,7 +47,7 @@
                                  alt=""/>
                         </div>
                         <div class="flex-grow-1 ms-3">
-                            <h4 class="h4"><a href="https://spatial.ala.org.au/" class="underline">Explore the Spatial Portal</a></h4>
+                            <h4 class="h4"><a href="https://spatial.ala.org.au/" class="text-decoration-underline">Explore the Spatial Portal</a></h4>
                             <p>Visualise and analyse relationships between species, location and environment.</p>
                         </div>
                     </div>
@@ -292,16 +292,16 @@
                     <div class="footer-menu-horizontal">
                         <ul id="menu-other-links" class="menu horizontal">
                             <li class="menu-item menu-item-type-post_type menu-item-object-page current_page_parent"><a
-                                    class="underline" href="==homeDomain==/blog/">News &amp; media</a>
+                                    class="text-decoration-underline" href="==homeDomain==/blog/">News &amp; media</a>
                             </li>
                             <li class="menu-item menu-item-type-custom menu-item-object-custom"><a
-                                    class="underline" href="https://support.ala.org.au/support/home">Help</a></li>
+                                    class="text-decoration-underline" href="https://support.ala.org.au/support/home">Help</a></li>
                             <li class="menu-item menu-item-type-custom menu-item-object-custom"><a
-                                    class="underline"
+                                    class="text-decoration-underline"
                                     href="https://support.ala.org.au/support/solutions/folders/6000233596">Developer
                                 tools &amp; documentation</a></li>
                             <li class="menu-item menu-item-type-post_type menu-item-object-page"><a
-                                    class="underline"
+                                    class="text-decoration-underline"
                                     href="==homeDomain==/sites-and-services/">All sites, services &amp;
                                 tools</a></li>
                         </ul>
@@ -316,9 +316,9 @@
             <div class="row">
                 <div class="col-md-6 content-column">
                     <h4>The ALA is made possible by contributions from its partners, is supported by <a
-                            href="https://www.dese.gov.au/ncris" class="underline">NCRIS</a>,
-                        is hosted by <a href="https://csiro.au/" class="underline">CSIRO</a>, and is the Australian node of <a
-                                href="https://www.gbif.org/en/" class="underline">GBIF</a>.</h4>
+                            href="https://www.dese.gov.au/ncris" class="text-decoration-underline">NCRIS</a>,
+                        is hosted by <a href="https://csiro.au/" class="text-decoration-underline">CSIRO</a>, and is the Australian node of <a
+                                href="https://www.gbif.org/en/" class="text-decoration-underline">GBIF</a>.</h4>
                     <p>
                         <a href="https://www.dese.gov.au/ncris"><img
                                 class="alignnone wp-image-41895 size-thumbnail"

--- a/source/html/testTemplate.html
+++ b/source/html/testTemplate.html
@@ -38,7 +38,14 @@ HEADER_HERE
                     <article class="post-166 page type-page status-publish hentry" id="post-166">
 
                         <div class="entry-content">
-
+                            <p>"class: entry-content" Paragraph text p: Sed ut perspiciatis unde omnis iste natus error sit voluptatem
+                                accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore
+                                veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam
+                                voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni
+                                dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui
+                                dolorem. </p>
+                        </div>
+                        <div>
                             <h2 class="wp-block-heading" id="what-is-the-ala">Heading h2<br></h2>
 
                             <p>Paragraph text p: Example text here with <a href="randomPage">an inline link</a>. </p>

--- a/source/html/testTemplate.html
+++ b/source/html/testTemplate.html
@@ -2,6 +2,7 @@
 <html lang="en-US">
 <head>
     <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <link rel="stylesheet" href="css/bootstrap.min.css">
     <link rel="stylesheet" href="css/bootstrap-theme.min.css">
     <link rel="stylesheet" href="css/ala-styles.min.css">

--- a/source/html/testTemplate.html
+++ b/source/html/testTemplate.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="css/autocomplete.min.css">
     <link rel="stylesheet" href="css/autocomplete-extra.min.css">
     <link rel="stylesheet" href="css/font-awesome.min.css">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
     <script src="js/jquery.min.js"></script>
     <script src="js/bootstrap.min.js"></script>
     <script src="js/autocomplete.min.js"></script>

--- a/source/html/testTemplate.html
+++ b/source/html/testTemplate.html
@@ -12,9 +12,17 @@
     <script src="js/bootstrap.min.js"></script>
     <script src="js/autocomplete.min.js"></script>
     <script src="js/application.js"></script>
+    <style>
+        .variant-label { background:#212121; color:#fff; font-family:monospace; font-size:13px; padding:6px 12px; margin:0; }
+        .variant-divider { border:3px solid #f26649; margin:0; }
+    </style>
 </head>
 <body>
-HEADER_HERE
+
+<!-- VARIANT 1: container / signedOut -->
+<p class="variant-label">&#9658; Variant 1: container / signedOut</p>
+<hr class="variant-divider">
+VARIANT_CONTAINER_SIGNEDOUT_HEADER
 <section id="breadcrumb">
     <div class="container">
         <div class="row">
@@ -26,17 +34,11 @@ HEADER_HERE
     </div>
 </section>
 <div class="wrapper" id="full-width-page-wrapper">
-
     <div class="container" id="content">
-
         <div class="row">
-
             <div class="col-md-12 content-area" id="primary">
-
                 <main class="site-main" id="main" role="main">
-
                     <article class="post-166 page type-page status-publish hentry" id="post-166">
-
                         <div class="entry-content">
                             <p>"class: entry-content" Paragraph text p: Sed ut perspiciatis unde omnis iste natus error sit voluptatem
                                 accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore
@@ -87,12 +89,9 @@ HEADER_HERE
                             <div class="card card-ala-light">
                                 <div class="card-body">
                                     <h4>.card.card-ala-light .card-body h4</h4>
-
                                     <p>p: Example text here with <a href="randomPage">an inline link</a>. </p>
-
                                     <p>
-                                        <button type="button" class="btn btn-outline-dark">button.btn.btn-outline-dark
-                                        </button>
+                                        <button type="button" class="btn btn-outline-dark">button.btn.btn-outline-dark</button>
                                     </p>
                                 </div>
                             </div>
@@ -101,30 +100,262 @@ HEADER_HERE
 
                             <div class="content">
                                 <h4 id="update-your-details">
-                                    <a href="randomPage">
-                                        Heading as a link: h4 a
-                                    </a>
+                                    <a href="randomPage">Heading as a link: h4 a</a>
                                 </h4>
                                 <p>Paragraph text</p>
                             </div>
 
                         </div><!-- .entry-content -->
 
-                        <footer class="entry-footer">
-
-                        </footer><!-- .entry-footer -->
+                        <footer class="entry-footer"></footer><!-- .entry-footer -->
 
                     </article><!-- #post-## -->
-
                 </main><!-- #main -->
-
             </div><!-- #primary -->
-
         </div><!-- .row end -->
-
     </div><!-- #content -->
-
 </div><!-- #full-width-page-wrapper -->
-FOOTER_HERE
+VARIANT_CONTAINER_SIGNEDOUT_FOOTER
+
+<!-- VARIANT 2: container / signedIn -->
+<p class="variant-label">&#9658; Variant 2: container / signedIn</p>
+<hr class="variant-divider">
+VARIANT_CONTAINER_SIGNEDIN_HEADER
+<section id="breadcrumb">
+    <div class="container">
+        <div class="row">
+            <ul class="breadcrumb-list">
+                <li><a href="/">Home</a></li>
+                <li class="active">Breadcrumb title</li>
+            </ul>
+        </div>
+    </div>
+</section>
+<div class="wrapper">
+    <div class="container" id="content">
+        <div class="row">
+            <div class="col-md-12 content-area" id="primary">
+                <main class="site-main" id="main" role="main">
+                    <article>
+                        <div class="entry-content">
+                            <p>Signed-in variant — profile and logout links should be visible above.</p>
+                            <p>Paragraph text p: Sed ut perspiciatis unde omnis iste natus error sit voluptatem
+                                accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore
+                                veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam
+                                voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni
+                                dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui
+                                dolorem. </p>
+                        </div>
+                        <div>
+                            <h2 class="wp-block-heading">Heading h2</h2>
+
+                            <p>Paragraph text p: Example text here with <a href="randomPage">an inline link</a>. </p>
+
+                            <h3 class="wp-block-heading">Heading h3: List</h3>
+                            <p>Intro p for list:</p>
+                            <ul>
+                                <li>Basic list item</li>
+                                <li>Basic list item with <a href="randomPage">link in the text</a></li>
+                                <li>Basic list item</li>
+                                <li>Basic list item with longer line length: Sed ut perspiciatis unde omnis iste natus
+                                    error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque
+                                    ipsa quae ab illo inventore veritatis
+                                </li>
+                            </ul>
+
+                            <h4>Heading h4: Buttons</h4>
+                            <p>
+                                <button type="button" class="btn btn-primary">button.btn.btn-primary</button>
+                            </p>
+                            <p>
+                                <button type="button" class="btn btn-outline-dark">button.btn.btn-outline-dark</button>
+                            </p>
+                            <p>
+                                <button type="button" class="btn btn-danger">button.btn.btn-danger</button>
+                            </p>
+
+                            <div class="card card-ala-light">
+                                <div class="card-body">
+                                    <h4>.card.card-ala-light .card-body h4</h4>
+                                    <p>p: Example text here with <a href="randomPage">an inline link</a>. </p>
+                                    <p>
+                                        <button type="button" class="btn btn-outline-dark">button.btn.btn-outline-dark</button>
+                                    </p>
+                                </div>
+                            </div>
+
+                            <div class="content">
+                                <h4><a href="randomPage">Heading as a link: h4 a</a></h4>
+                                <p>Paragraph text</p>
+                            </div>
+                        </div>
+                    </article>
+                </main>
+            </div>
+        </div>
+    </div>
+</div>
+VARIANT_CONTAINER_SIGNEDIN_FOOTER
+
+<!-- VARIANT 3: container-fluid / signedOut -->
+<p class="variant-label">&#9658; Variant 3: container-fluid / signedOut</p>
+<hr class="variant-divider">
+VARIANT_FLUID_SIGNEDOUT_HEADER
+<section id="breadcrumb">
+    <div class="container-fluid">
+        <div class="row">
+            <ul class="breadcrumb-list">
+                <li><a href="/">Home</a></li>
+                <li class="active">Breadcrumb title</li>
+            </ul>
+        </div>
+    </div>
+</section>
+<div class="wrapper">
+    <div class="container-fluid" id="content">
+        <div class="row">
+            <div class="col-md-12 content-area" id="primary">
+                <main class="site-main" id="main" role="main">
+                    <article>
+                        <div class="entry-content">
+                            <p>Fluid layout signed-out variant — navbar and search bar use full width.</p>
+                            <p>Paragraph text p: Sed ut perspiciatis unde omnis iste natus error sit voluptatem
+                                accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore
+                                veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam
+                                voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni
+                                dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui
+                                dolorem. </p>
+                        </div>
+                        <div>
+                            <h2 class="wp-block-heading">Heading h2</h2>
+
+                            <p>Paragraph text p: Example text here with <a href="randomPage">an inline link</a>. </p>
+
+                            <h3 class="wp-block-heading">Heading h3: List</h3>
+                            <p>Intro p for list:</p>
+                            <ul>
+                                <li>Basic list item</li>
+                                <li>Basic list item with <a href="randomPage">link in the text</a></li>
+                                <li>Basic list item</li>
+                                <li>Basic list item with longer line length: Sed ut perspiciatis unde omnis iste natus
+                                    error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque
+                                    ipsa quae ab illo inventore veritatis
+                                </li>
+                            </ul>
+
+                            <h4>Heading h4: Buttons</h4>
+                            <p>
+                                <button type="button" class="btn btn-primary">button.btn.btn-primary</button>
+                            </p>
+                            <p>
+                                <button type="button" class="btn btn-outline-dark">button.btn.btn-outline-dark</button>
+                            </p>
+                            <p>
+                                <button type="button" class="btn btn-danger">button.btn.btn-danger</button>
+                            </p>
+
+                            <div class="card card-ala-light">
+                                <div class="card-body">
+                                    <h4>.card.card-ala-light .card-body h4</h4>
+                                    <p>p: Example text here with <a href="randomPage">an inline link</a>. </p>
+                                    <p>
+                                        <button type="button" class="btn btn-outline-dark">button.btn.btn-outline-dark</button>
+                                    </p>
+                                </div>
+                            </div>
+
+                            <div class="content">
+                                <h4><a href="randomPage">Heading as a link: h4 a</a></h4>
+                                <p>Paragraph text</p>
+                            </div>
+                        </div>
+                    </article>
+                </main>
+            </div>
+        </div>
+    </div>
+</div>
+VARIANT_FLUID_SIGNEDOUT_FOOTER
+
+<!-- VARIANT 4: container-fluid / signedIn -->
+<p class="variant-label">&#9658; Variant 4: container-fluid / signedIn</p>
+<hr class="variant-divider">
+VARIANT_FLUID_SIGNEDIN_HEADER
+<section id="breadcrumb">
+    <div class="container-fluid">
+        <div class="row">
+            <ul class="breadcrumb-list">
+                <li><a href="/">Home</a></li>
+                <li class="active">Breadcrumb title</li>
+            </ul>
+        </div>
+    </div>
+</section>
+<div class="wrapper">
+    <div class="container-fluid" id="content">
+        <div class="row">
+            <div class="col-md-12 content-area" id="primary">
+                <main class="site-main" id="main" role="main">
+                    <article>
+                        <div class="entry-content">
+                            <p>Fluid layout signed-in variant — profile and logout links should be visible above.</p>
+                            <p>Paragraph text p: Sed ut perspiciatis unde omnis iste natus error sit voluptatem
+                                accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore
+                                veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam
+                                voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni
+                                dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui
+                                dolorem. </p>
+                        </div>
+                        <div>
+                            <h2 class="wp-block-heading">Heading h2</h2>
+
+                            <p>Paragraph text p: Example text here with <a href="randomPage">an inline link</a>. </p>
+
+                            <h3 class="wp-block-heading">Heading h3: List</h3>
+                            <p>Intro p for list:</p>
+                            <ul>
+                                <li>Basic list item</li>
+                                <li>Basic list item with <a href="randomPage">link in the text</a></li>
+                                <li>Basic list item</li>
+                                <li>Basic list item with longer line length: Sed ut perspiciatis unde omnis iste natus
+                                    error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque
+                                    ipsa quae ab illo inventore veritatis
+                                </li>
+                            </ul>
+
+                            <h4>Heading h4: Buttons</h4>
+                            <p>
+                                <button type="button" class="btn btn-primary">button.btn.btn-primary</button>
+                            </p>
+                            <p>
+                                <button type="button" class="btn btn-outline-dark">button.btn.btn-outline-dark</button>
+                            </p>
+                            <p>
+                                <button type="button" class="btn btn-danger">button.btn.btn-danger</button>
+                            </p>
+
+                            <div class="card card-ala-light">
+                                <div class="card-body">
+                                    <h4>.card.card-ala-light .card-body h4</h4>
+                                    <p>p: Example text here with <a href="randomPage">an inline link</a>. </p>
+                                    <p>
+                                        <button type="button" class="btn btn-outline-dark">button.btn.btn-outline-dark</button>
+                                    </p>
+                                </div>
+                            </div>
+
+                            <div class="content">
+                                <h4><a href="randomPage">Heading as a link: h4 a</a></h4>
+                                <p>Paragraph text</p>
+                            </div>
+                        </div>
+                    </article>
+                </main>
+            </div>
+        </div>
+    </div>
+</div>
+VARIANT_FLUID_SIGNEDIN_FOOTER
+
 </body>
 </html>

--- a/source/html/testTemplate.html
+++ b/source/html/testTemplate.html
@@ -27,77 +27,95 @@ HEADER_HERE
 </section>
 <div class="wrapper" id="full-width-page-wrapper">
 
-	<div class="container" id="content">
+    <div class="container" id="content">
 
-		<div class="row">
+        <div class="row">
 
-			<div class="col-md-12 content-area" id="primary">
+            <div class="col-md-12 content-area" id="primary">
 
-				<main class="site-main" id="main" role="main">
+                <main class="site-main" id="main" role="main">
 
-<article class="post-166 page type-page status-publish hentry" id="post-166">
-	
-	<div class="entry-content">
-		
-<h2 class="wp-block-heading" id="what-is-the-ala">Heading h2<br></h2>
+                    <article class="post-166 page type-page status-publish hentry" id="post-166">
 
-<p>Paragraph text p: Example text here with <a href="randomPage">an inline link</a>. </p>
+                        <div class="entry-content">
 
-<p>Paragraph text p: Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem. </p>
+                            <h2 class="wp-block-heading" id="what-is-the-ala">Heading h2<br></h2>
 
-<div style="height:20px" aria-hidden="true" class="wp-block-spacer"></div>
+                            <p>Paragraph text p: Example text here with <a href="randomPage">an inline link</a>. </p>
 
-<h3 class="wp-block-heading" id="our-users">Heading h3: List</h3>
+                            <p>Paragraph text p: Sed ut perspiciatis unde omnis iste natus error sit voluptatem
+                                accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore
+                                veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam
+                                voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni
+                                dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui
+                                dolorem. </p>
 
-<p>Intro p for list:</p>
+                            <div style="height:20px" aria-hidden="true" class="wp-block-spacer"></div>
 
-<ul><li>Basic list item</li>
-    <li>Basic list item with <a href="randomPage">link in the text</a></li>
-    <li>Basic list item</li>
-    <li>Basic list item with longer line length: Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis</li>
-</ul>
+                            <h3 class="wp-block-heading" id="our-users">Heading h3: List</h3>
 
-<h4>Heading h4: Buttons</h4>
-    <p><button type="button" class="btn btn-primary">button.btn.btn-primary</button></p>
-    <p><button type="button" class="btn btn-outline-dark">button.btn.btn-outline-dark</button></p>
-    <p><button type="button" class="btn btn-danger">button.btn.btn-danger</button></p>
+                            <p>Intro p for list:</p>
 
-    <div class="card card-ala-light">
-          <div class="card-body">
-            <h4>.card.card-ala-light .card-body h4</h4>
-        
-            <p>p: Example text here with <a href="randomPage">an inline link</a>. </p>
+                            <ul>
+                                <li>Basic list item</li>
+                                <li>Basic list item with <a href="randomPage">link in the text</a></li>
+                                <li>Basic list item</li>
+                                <li>Basic list item with longer line length: Sed ut perspiciatis unde omnis iste natus
+                                    error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque
+                                    ipsa quae ab illo inventore veritatis
+                                </li>
+                            </ul>
 
-            <p><button type="button" class="btn btn-outline-dark">button.btn.btn-outline-dark</button></p>
-          </div>
-        </div>
+                            <h4>Heading h4: Buttons</h4>
+                            <p>
+                                <button type="button" class="btn btn-primary">button.btn.btn-primary</button>
+                            </p>
+                            <p>
+                                <button type="button" class="btn btn-outline-dark">button.btn.btn-outline-dark</button>
+                            </p>
+                            <p>
+                                <button type="button" class="btn btn-danger">button.btn.btn-danger</button>
+                            </p>
 
-<div style="height:20px" aria-hidden="true" class="wp-block-spacer"></div>
+                            <div class="card card-ala-light">
+                                <div class="card-body">
+                                    <h4>.card.card-ala-light .card-body h4</h4>
 
-                    <div class="content">
-                            <h4 id="update-your-details">
-                                <a href="randomPage">
-                                    Heading as a link: h4 a
-                                </a>
-                              </h4>
-                            <p>Paragraph text</p>
-                        </div>
-		
-	</div><!-- .entry-content -->
+                                    <p>p: Example text here with <a href="randomPage">an inline link</a>. </p>
 
-	<footer class="entry-footer">
-		
-	</footer><!-- .entry-footer -->
+                                    <p>
+                                        <button type="button" class="btn btn-outline-dark">button.btn.btn-outline-dark
+                                        </button>
+                                    </p>
+                                </div>
+                            </div>
 
-</article><!-- #post-## -->
+                            <div style="height:20px" aria-hidden="true" class="wp-block-spacer"></div>
 
-				</main><!-- #main -->
+                            <div class="content">
+                                <h4 id="update-your-details">
+                                    <a href="randomPage">
+                                        Heading as a link: h4 a
+                                    </a>
+                                </h4>
+                                <p>Paragraph text</p>
+                            </div>
 
-			</div><!-- #primary -->
+                        </div><!-- .entry-content -->
 
-		</div><!-- .row end -->
+                        <footer class="entry-footer">
 
-	</div><!-- #content -->
+                        </footer><!-- .entry-footer -->
+
+                    </article><!-- #post-## -->
+
+                </main><!-- #main -->
+
+            </div><!-- #primary -->
+
+        </div><!-- .row end -->
+
+    </div><!-- #content -->
 
 </div><!-- #full-width-page-wrapper -->
 FOOTER_HERE

--- a/source/scss/bootstrap-ala.scss
+++ b/source/scss/bootstrap-ala.scss
@@ -35,12 +35,7 @@ $body-bg:               #fff !default;
 //** Global text color on `<body>`.
 $text-color:            $gray-darker !default;
 
-//** Global textual link color.
-$link-color:            #c44d34 !default;
-//** Link hover color set via `darken()` function.
-$link-hover-color:      darken($link-color, 15%) !default;
-//** Link hover decoration.
-$link-hover-decoration: underline !default;
+//** Global textual link color — set authoritatively before the Bootstrap @import below.
 
 
 //== Typography
@@ -162,9 +157,17 @@ $h4-font-size:      1.125rem; // 18px
 $h5-font-size:      0.875rem; // 14px
 $h6-font-size:      0.75rem;  // 12px
 
+// Links: match BS3  a { color: #c44d34; text-decoration: none }
+//        and BS3  a:hover, a:focus { text-decoration: underline } (explicit because $link-decoration is none)
+$link-color:             #c44d34;
+$link-decoration:        none;
+$link-hover-decoration:  underline;
+// $link-hover-color is computed by BS5 as shift-color($link-color) → ~#883524, matching BS3 darken(15%)
+
 @import "../vendor/bootstrap/scss/bootstrap.scss";
 @import "./old-theme/child_theme_variables";
 @import "./old-theme/child_theme";
+
 
 #wrapper-navbar {
   @import "./old-theme/partials/header";

--- a/source/scss/bootstrap-ala.scss
+++ b/source/scss/bootstrap-ala.scss
@@ -105,7 +105,7 @@ $input-color-placeholder:        $gray-light !default;
 //== Dropdowns
 //
 //## Dropdown menu container and contents.
-$dropdown-font-size: 14px;
+// $dropdown-font-size intentionally omitted — inherits from $font-size-base (0.875rem = 14px)
 
 //** Divider color for between dropdown items.
 $dropdown-divider-bg:            $gray-light !default;
@@ -151,6 +151,16 @@ $thumbnail-border:            #999 !default;
 // Font
 $icon-font-path: "../fonts/";
 @import url(https://fonts.googleapis.com/css?family=Lato%3A700%7CRoboto%3A300%2C400%2C400i%2C500%2C700%2C900&ver=5.2.1);
+
+//== Typography: match BS3 pixel sizes expressed as rem (browser default 1rem = 16px)
+// BS3 body was 14px; headings were: h1=36px, h2=30px, h3=24px, h4=18px, h5=14px, h6=12px
+$font-size-base:    0.875rem; // 14px
+$h1-font-size:      2.25rem;  // 36px
+$h2-font-size:      1.875rem; // 30px
+$h3-font-size:      1.5rem;   // 24px
+$h4-font-size:      1.125rem; // 18px
+$h5-font-size:      0.875rem; // 14px
+$h6-font-size:      0.75rem;  // 12px
 
 @import "../vendor/bootstrap/scss/bootstrap.scss";
 @import "./old-theme/child_theme_variables";

--- a/source/scss/bootstrap-ala.scss
+++ b/source/scss/bootstrap-ala.scss
@@ -150,6 +150,7 @@ $icon-font-path: "../fonts/";
 //== Typography: match BS3 pixel sizes expressed as rem (browser default 1rem = 16px)
 // BS3 body was 14px; headings were: h1=36px, h2=30px, h3=24px, h4=18px, h5=14px, h6=12px
 $font-size-base:    0.875rem; // 14px
+$line-height-base:  1.4286;   // 20px (20 / 14)
 $h1-font-size:      2.25rem;  // 36px
 $h2-font-size:      1.875rem; // 30px
 $h3-font-size:      1.5rem;   // 24px

--- a/source/scss/old-theme/_child_theme.scss
+++ b/source/scss/old-theme/_child_theme.scss
@@ -183,8 +183,4 @@ ul.menu {
   @extend .btn-primary;
 }
 
-/* Bootstrap 3 related styles*/
-#content a {
-  text-decoration: none;
-}
 

--- a/source/scss/old-theme/_child_theme_variables.scss
+++ b/source/scss/old-theme/_child_theme_variables.scss
@@ -135,14 +135,16 @@ $headings-font-family: 'Lato', sans-serif;
 $headings-font-weight: 700;
 $headings-line-height: 1.2;
 
-$font-size-base: .875rem;
-
-$h1-font-size: $font-size-base * 3 !default;
-$h2-font-size: $font-size-base * 2 !default;
-$h3-font-size: $font-size-base * 1.75 !default;
-$h4-font-size: $font-size-base * 1.285 !default;
-$h5-font-size: $font-size-base * 1.1 !default;
-$h6-font-size: $font-size-base !default;
+// $font-size-base is set to 0.875rem (14px) before the Bootstrap @import in bootstrap-ala.scss.
+// Heading sizes below match the original BS3 pixel values converted to rem (1rem = 16px browser default):
+// h1=36px, h2=30px, h3=24px, h4=18px, h5=14px, h6=12px
+$font-size-base: 0.875rem;  // 14px
+$h1-font-size:   2.25rem;   // 36px
+$h2-font-size:   1.875rem;  // 30px
+$h3-font-size:   1.5rem;    // 24px
+$h4-font-size:   1.125rem;  // 18px
+$h5-font-size:   0.875rem;  // 14px
+$h6-font-size:   0.75rem;   // 12px
 
 $link-color: $primary-dark;
 $link-decoration: underline;

--- a/source/scss/old-theme/_child_theme_variables.scss
+++ b/source/scss/old-theme/_child_theme_variables.scss
@@ -147,7 +147,7 @@ $h5-font-size:   0.875rem;  // 14px
 $h6-font-size:   0.75rem;   // 12px
 
 $link-color: $primary-dark;
-$link-decoration: underline;
+$link-decoration: none;
 
 // Pagination
 

--- a/source/scss/old-theme/partials/_footer.scss
+++ b/source/scss/old-theme/partials/_footer.scss
@@ -19,6 +19,7 @@
     .btn {
       margin-right: 10px;
       font-size: 12px;
+      line-height: 20px;
     }
     .social {
       margin: 0 0 0 5px;
@@ -134,7 +135,7 @@
     a {
       color: $c-text;
       font-weight: 500;
-      font-size: 1rem;
+      font-size: $font-size-base;
       display: inline-block;
       margin-bottom: 5px;
     }
@@ -153,6 +154,9 @@
   padding-top: 50px;
   padding-bottom: 50px;
   color: $c-text-light;
+  h4, .h4 {
+    line-height: 1.1; // (matches BS3)
+  }
   img {
     margin-top: 20px;
   }

--- a/source/scss/old-theme/partials/_header.scss
+++ b/source/scss/old-theme/partials/_header.scss
@@ -19,6 +19,7 @@ $background-color-header: rgba(0,0,0,0.85) !important;
     display: flex;
     align-items: center;
     justify-content: space-between;
+    gap: 1rem;
   }
 
   > .header-logo-menu:after,
@@ -38,6 +39,8 @@ $background-color-header: rgba(0,0,0,0.85) !important;
     > .header-logo-menu {
       flex-wrap: nowrap;
       display: block;
+      padding-left: 0;
+      padding-right: 0;
 
       .navbar-brand {
         display: flex;
@@ -145,10 +148,11 @@ $background-color-header: rgba(0,0,0,0.85) !important;
     }
   }
   #navbarOuterWrapper {
+    display: flex;
     flex-direction: column;
     align-items: flex-end;
   }
-  &.navbar-expand-md {
+  &.navbar-expand-lg {
     .navbar-nav {
       .nav-link {
           padding: 8px;
@@ -157,13 +161,25 @@ $background-color-header: rgba(0,0,0,0.85) !important;
     }
   }
 
-  .navbar-toggle {
+  .navbar-toggle,
+  .mobile-nav-toggle {
+    display: flex;
+    flex: 0 0 auto;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
     border: 0px;
     background-color: transparent;
-    margin: 4px 8px 4px 8px;
+    margin: 4px 0 4px 4px;
     padding: 2px 0 2px 0;
     height: 37px;
-    width: 41px;
+    width: 30px;
+    cursor: pointer;
+
+    svg path {
+      transition: all 150ms ease;
+      fill: #fff;
+    }
 
     .horizontal-line {
       height: 2px;
@@ -171,16 +187,20 @@ $background-color-header: rgba(0,0,0,0.85) !important;
       border: 1px solid white;
       border-radius: 1px;
       background-color: white;
-      margin-bottom: 4px;
+      margin: 0;
     }
 
-    .horizontal-line:first-child {
+    .horizontal-line + .horizontal-line {
       margin-top: 4px;
     }
 
     &:hover .horizontal-line, &:focus .horizontal-line {
       background-color: $primary;
       border-color: $primary;
+    }
+
+    &:hover svg path, &:focus svg path {
+      fill: $primary;
     }
   }
 
@@ -253,6 +273,7 @@ $background-color-header: rgba(0,0,0,0.85) !important;
     display: flex;
     justify-content: space-between;
     align-items: center;
+    flex: 0 0 auto;
     margin-right: 0;
     margin-left: 0;
   }
@@ -296,13 +317,42 @@ $background-color-header: rgba(0,0,0,0.85) !important;
 .main-nav-wrapper {
   display: flex;
   flex-direction: row;
+  align-items: center;
   justify-content: flex-end;
+  width: 100%;
+  min-width: 0;
 }
 
 #navbarNavDropdown {
+  flex: 1 1 auto;
+  min-width: 0;
   margin-right: 20px;
   padding-right: 20px;
   border-right: 1px solid rgba(255,255,255,0.4);
+}
+
+@include media-breakpoint-up(lg) {
+  .navbar {
+    > .header-logo-menu {
+      flex-wrap: nowrap;
+    }
+
+    #navbarOuterWrapper {
+      flex: 1 1 auto;
+      min-width: 0;
+      margin-left: auto;
+    }
+
+    #navbarNavDropdown {
+      .navbar-nav {
+        width: 100%;
+        flex-wrap: wrap;
+        justify-content: flex-end;
+        align-content: flex-end;
+        row-gap: 0.25rem;
+      }
+    }
+  }
 }
 
 .search-trigger, .account-mobile, .search-submit {
@@ -379,6 +429,69 @@ $background-color-header: rgba(0,0,0,0.85) !important;
 }
 
 @include media-breakpoint-down(lg){
+  .navbar {
+    overflow-x: hidden;
+
+    > .header-logo-menu,
+    .navbar-header,
+    .navbar-header > .display-flex {
+      max-width: 100%;
+      overflow-x: hidden;
+    }
+
+    #navbarOuterWrapper {
+      display: block;
+      width: 100%;
+    }
+
+    .top-bar {
+      display: none !important;
+    }
+
+    .main-nav-wrapper {
+      display: block;
+      width: 100%;
+    }
+
+    #navbarNavDropdown {
+      width: 100%;
+      margin-right: 0;
+      padding-right: 0;
+      border-right: none;
+    }
+
+    #navbarNavDropdown.show,
+    #navbarNavDropdown.collapsing {
+      margin-top: 0.75rem;
+    }
+
+    #navbarNavDropdown .navbar-nav {
+      width: 100%;
+      flex-direction: column;
+      align-items: stretch;
+      margin-top: 0;
+    }
+
+    #navbarNavDropdown .nav-item,
+    #navbarNavDropdown .nav-link {
+      width: 100%;
+    }
+
+    #navbarNavDropdown .dropdown-menu {
+      position: static;
+      float: none;
+      width: auto;
+      margin-top: 0;
+      border: 0;
+      box-shadow: none;
+    }
+
+    #navbarNavDropdown .dropdown-item,
+    #navbarNavDropdown .dropdown-header {
+      padding: 5px 15px 5px 25px;
+    }
+  }
+
   .site {
     position: relative;
     right: 0;

--- a/source/scss/old-theme/partials/_header.scss
+++ b/source/scss/old-theme/partials/_header.scss
@@ -75,10 +75,35 @@ $background-color-header: rgba(0,0,0,0.85) !important;
     }
   }
   .navbar-nav{
+    // BS3 navbar dropdown: no top radius, square corners flush with nav bar
+    .dropdown-menu {
+      --bs-dropdown-border-radius: 0;
+      --bs-dropdown-padding-y: 5px;
+      --bs-dropdown-font-size: 14px;
+      --bs-dropdown-border-color: rgba(0, 0, 0, .15);
+      --bs-dropdown-box-shadow: 0 6px 12px rgba(0, 0, 0, .175);
+      --bs-dropdown-link-color: #343a40;
+      --bs-dropdown-link-hover-color: #292d32;
+      --bs-dropdown-link-hover-bg: #f2f2f2;
+      --bs-dropdown-item-padding-y: 3px;
+      --bs-dropdown-item-padding-x: 20px;
+      margin-top: 0;
+      border-top-left-radius: 0;
+      border-top-right-radius: 0;
+      box-shadow: 0 6px 12px rgba(0, 0, 0, .175);
+    }
+
     .nav-link {
       position: relative;
       text-decoration: none;
       font-size: 18px;
+
+      // Override the global nav-link:hover background (grey for tabs/pills)
+      // — navbar links sit on a dark background so must stay transparent.
+      &:hover, &:focus {
+        background-color: transparent;
+      }
+
       &:before {
         content: '';
         display: block;
@@ -97,11 +122,22 @@ $background-color-header: rgba(0,0,0,0.85) !important;
         }
       }
     }
+
+    // BS3 used a 4px .caret at vertical-align: middle.
+    // BS5 .dropdown-toggle::after is 0.3em and sits high (vertical-align: 0.255em).
+    .dropdown-toggle::after {
+      border-top-width: 4px;
+      border-right-width: 4px;
+      border-left-width: 4px;
+      vertical-align: middle;
+      margin-left: 2px;
+    }
     .dropdown-item {
       text-decoration: none;
     }
 
-    .menu-item:hover, .current-menu-item, .current-menu-parent {
+    .menu-item:hover, .current-menu-item, .current-menu-parent,
+    .nav-item:hover, .nav-item.show {
       > .nav-link:before {
         left: 0;
         width: 100%;
@@ -477,6 +513,47 @@ form.search-form {
 }
 
 &>nav {
+  // BS3 applied wider padding to all buttons inside the navbar
+  .btn, .gform_button {
+    padding: 5px 30px;
+    line-height: 20px;
+  }
+
+  // btn-sm inside the navbar keeps the compact sm padding
+  .btn-sm, .btn-group-sm > .btn, .btn-group-sm > .gform_button {
+    padding: 4px 18px;
+    line-height: 20px;
+  }
+
+  // BS3 btn-primary colour/shadow inside the navbar differs from the global definition
+  .btn-primary, .gform_button {
+    --bs-btn-color: #212121;
+    --bs-btn-bg: #f26649;
+    --bs-btn-border-color: #f26649;
+    --bs-btn-hover-color: #212121;
+    --bs-btn-hover-bg: #ef4825;
+    --bs-btn-hover-border-color: #ef3e19;
+    --bs-btn-active-color: #fff;
+    --bs-btn-active-bg: #ef3e19;
+    --bs-btn-active-border-color: #eb3611;
+    --bs-btn-disabled-color: #212121;
+    --bs-btn-disabled-bg: #f26649;
+    --bs-btn-disabled-border-color: #f26649;
+    --bs-btn-box-shadow: inset 0 1px 0 rgba(255, 255, 255, .15), 0 1px 1px rgba(0, 0, 0, .075);
+  }
+
+  // BS3 focus box-shadows for buttons inside the navbar
+  .btn:focus, .gform_button:focus, .btn.focus, .focus.gform_button {
+    outline: 0;
+    box-shadow: 0 0 0 .2rem rgba(242, 102, 73, .25);
+  }
+  .btn-primary:focus, .btn-primary.focus {
+    box-shadow: 0 0 0 .2rem rgba(242, 102, 73, .5);
+  }
+  .btn-outline-light:focus, .btn-outline-light.focus {
+    box-shadow: 0 0 0 .2rem rgba(255, 255, 255, .5);
+  }
+
   .account-mobile {
     display: flex;
   }


### PR DESCRIPTION
Imported some of the in-use bs3 styles to override the default bs5 changes. For a list of what changed see the individual commit titles.

I did notice that the old header and footer used different styles than other applications. Some of the changes made are to separate the header/footer only styles.

Expanded the testTemplate.html. If you scroll through it you will see 4 variations of header/footer corresponding to container/container-fluid and signedIn/signedOut. It did not need to duplicate all of the content for all 3 sections, but I left it that way. 

Some of the gulpfile.js changes are redundant. The build of the header/footer test variations was the major change here.

